### PR TITLE
Get for readonly dictionaries

### DIFF
--- a/src/FuncSharp/Extensions/IDictionaryExtensions.cs
+++ b/src/FuncSharp/Extensions/IDictionaryExtensions.cs
@@ -12,5 +12,22 @@ namespace FuncSharp
             }
             return new Tryer<K, V>(dictionary.TryGetValue).Invoke(key);
         }
+
+        public static IOption<V> Get<K, V>(this IEnumerable<KeyValuePair<K, V>> collection, K key)
+        {
+            if (Equals(key, null))
+            {
+                return Option.Empty<V>();
+            }
+            if (collection is IDictionary<K,V>)
+            {
+                return Get((IDictionary<K,V>)collection, key);
+            }
+            if (collection is IReadOnlyDictionary<K,V>)
+            {
+                return new Tryer<K, V>(((IDictionary<K, V>)collection).TryGetValue).Invoke(key);
+            }
+            return collection.FirstOption(kvp => kvp.Key.Equals(key)).Map(kvp => kvp.Value);
+        }
     }
 }


### PR DESCRIPTION
Get for readonly dictionaries. Can't just implement an extension method for IReadOnlyDictionary as it'll break existing code where we pass a Dictionary (compiler can't choose between the two equally good options; Dictionary implements both interfaces, IDictionary does not implement IReadOnlyDictionary).

By leaving the original IDictionary method in, we make sure performance doesn't take a hit in current use cases.

Casting like this is a similar approach to Microsoft's (e.g. for Enumerable<T>.Select)
