### PR TITLE
Value based match made type safe

### DIFF
--- a/src/FuncSharp/Extensions/ObjectExtensions.cs
+++ b/src/FuncSharp/Extensions/ObjectExtensions.cs
@@ -117,10 +117,10 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -132,10 +132,10 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -223,11 +223,11 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -239,11 +239,11 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -339,12 +339,12 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -356,12 +356,12 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -465,13 +465,13 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -483,13 +483,13 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -601,14 +601,14 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -620,14 +620,14 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -747,15 +747,15 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, T6, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            T6 t6, Func<T6, TResult> f6,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            T t6, Func<T, TResult> f6,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -767,15 +767,15 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5, T6>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            T6 t6, Action<T6> f6,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            T t6, Action<T> f6,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -903,16 +903,16 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, T6, T7, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            T6 t6, Func<T6, TResult> f6,
-            T7 t7, Func<T7, TResult> f7,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            T t6, Func<T, TResult> f6,
+            T t7, Func<T, TResult> f7,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -924,16 +924,16 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5, T6, T7>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            T6 t6, Action<T6> f6,
-            T7 t7, Action<T7> f7,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            T t6, Action<T> f6,
+            T t7, Action<T> f7,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -1069,17 +1069,17 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            T6 t6, Func<T6, TResult> f6,
-            T7 t7, Func<T7, TResult> f7,
-            T8 t8, Func<T8, TResult> f8,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            T t6, Func<T, TResult> f6,
+            T t7, Func<T, TResult> f7,
+            T t8, Func<T, TResult> f8,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -1091,17 +1091,17 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            T6 t6, Action<T6> f6,
-            T7 t7, Action<T7> f7,
-            T8 t8, Action<T8> f8,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            T t6, Action<T> f6,
+            T t7, Action<T> f7,
+            T t8, Action<T> f8,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -1245,18 +1245,18 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            T6 t6, Func<T6, TResult> f6,
-            T7 t7, Func<T7, TResult> f7,
-            T8 t8, Func<T8, TResult> f8,
-            T9 t9, Func<T9, TResult> f9,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            T t6, Func<T, TResult> f6,
+            T t7, Func<T, TResult> f7,
+            T t8, Func<T, TResult> f8,
+            T t9, Func<T, TResult> f9,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -1268,18 +1268,18 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            T6 t6, Action<T6> f6,
-            T7 t7, Action<T7> f7,
-            T8 t8, Action<T8> f8,
-            T9 t9, Action<T9> f9,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            T t6, Action<T> f6,
+            T t7, Action<T> f7,
+            T t8, Action<T> f8,
+            T t9, Action<T> f9,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -1431,19 +1431,19 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            T6 t6, Func<T6, TResult> f6,
-            T7 t7, Func<T7, TResult> f7,
-            T8 t8, Func<T8, TResult> f8,
-            T9 t9, Func<T9, TResult> f9,
-            T10 t10, Func<T10, TResult> f10,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            T t6, Func<T, TResult> f6,
+            T t7, Func<T, TResult> f7,
+            T t8, Func<T, TResult> f8,
+            T t9, Func<T, TResult> f9,
+            T t10, Func<T, TResult> f10,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -1455,19 +1455,19 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            T6 t6, Action<T6> f6,
-            T7 t7, Action<T7> f7,
-            T8 t8, Action<T8> f8,
-            T9 t9, Action<T9> f9,
-            T10 t10, Action<T10> f10,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            T t6, Action<T> f6,
+            T t7, Action<T> f7,
+            T t8, Action<T> f8,
+            T t9, Action<T> f9,
+            T t10, Action<T> f10,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -1627,20 +1627,20 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            T6 t6, Func<T6, TResult> f6,
-            T7 t7, Func<T7, TResult> f7,
-            T8 t8, Func<T8, TResult> f8,
-            T9 t9, Func<T9, TResult> f9,
-            T10 t10, Func<T10, TResult> f10,
-            T11 t11, Func<T11, TResult> f11,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            T t6, Func<T, TResult> f6,
+            T t7, Func<T, TResult> f7,
+            T t8, Func<T, TResult> f8,
+            T t9, Func<T, TResult> f9,
+            T t10, Func<T, TResult> f10,
+            T t11, Func<T, TResult> f11,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -1652,20 +1652,20 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            T6 t6, Action<T6> f6,
-            T7 t7, Action<T7> f7,
-            T8 t8, Action<T8> f8,
-            T9 t9, Action<T9> f9,
-            T10 t10, Action<T10> f10,
-            T11 t11, Action<T11> f11,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            T t6, Action<T> f6,
+            T t7, Action<T> f7,
+            T t8, Action<T> f8,
+            T t9, Action<T> f9,
+            T t10, Action<T> f10,
+            T t11, Action<T> f11,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -1833,21 +1833,21 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            T6 t6, Func<T6, TResult> f6,
-            T7 t7, Func<T7, TResult> f7,
-            T8 t8, Func<T8, TResult> f8,
-            T9 t9, Func<T9, TResult> f9,
-            T10 t10, Func<T10, TResult> f10,
-            T11 t11, Func<T11, TResult> f11,
-            T12 t12, Func<T12, TResult> f12,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            T t6, Func<T, TResult> f6,
+            T t7, Func<T, TResult> f7,
+            T t8, Func<T, TResult> f8,
+            T t9, Func<T, TResult> f9,
+            T t10, Func<T, TResult> f10,
+            T t11, Func<T, TResult> f11,
+            T t12, Func<T, TResult> f12,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -1859,21 +1859,21 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            T6 t6, Action<T6> f6,
-            T7 t7, Action<T7> f7,
-            T8 t8, Action<T8> f8,
-            T9 t9, Action<T9> f9,
-            T10 t10, Action<T10> f10,
-            T11 t11, Action<T11> f11,
-            T12 t12, Action<T12> f12,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            T t6, Action<T> f6,
+            T t7, Action<T> f7,
+            T t8, Action<T> f8,
+            T t9, Action<T> f9,
+            T t10, Action<T> f10,
+            T t11, Action<T> f11,
+            T t12, Action<T> f12,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -2049,22 +2049,22 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            T6 t6, Func<T6, TResult> f6,
-            T7 t7, Func<T7, TResult> f7,
-            T8 t8, Func<T8, TResult> f8,
-            T9 t9, Func<T9, TResult> f9,
-            T10 t10, Func<T10, TResult> f10,
-            T11 t11, Func<T11, TResult> f11,
-            T12 t12, Func<T12, TResult> f12,
-            T13 t13, Func<T13, TResult> f13,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            T t6, Func<T, TResult> f6,
+            T t7, Func<T, TResult> f7,
+            T t8, Func<T, TResult> f8,
+            T t9, Func<T, TResult> f9,
+            T t10, Func<T, TResult> f10,
+            T t11, Func<T, TResult> f11,
+            T t12, Func<T, TResult> f12,
+            T t13, Func<T, TResult> f13,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -2076,22 +2076,22 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            T6 t6, Action<T6> f6,
-            T7 t7, Action<T7> f7,
-            T8 t8, Action<T8> f8,
-            T9 t9, Action<T9> f9,
-            T10 t10, Action<T10> f10,
-            T11 t11, Action<T11> f11,
-            T12 t12, Action<T12> f12,
-            T13 t13, Action<T13> f13,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            T t6, Action<T> f6,
+            T t7, Action<T> f7,
+            T t8, Action<T> f8,
+            T t9, Action<T> f9,
+            T t10, Action<T> f10,
+            T t11, Action<T> f11,
+            T t12, Action<T> f12,
+            T t13, Action<T> f13,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -2275,23 +2275,23 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            T6 t6, Func<T6, TResult> f6,
-            T7 t7, Func<T7, TResult> f7,
-            T8 t8, Func<T8, TResult> f8,
-            T9 t9, Func<T9, TResult> f9,
-            T10 t10, Func<T10, TResult> f10,
-            T11 t11, Func<T11, TResult> f11,
-            T12 t12, Func<T12, TResult> f12,
-            T13 t13, Func<T13, TResult> f13,
-            T14 t14, Func<T14, TResult> f14,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            T t6, Func<T, TResult> f6,
+            T t7, Func<T, TResult> f7,
+            T t8, Func<T, TResult> f8,
+            T t9, Func<T, TResult> f9,
+            T t10, Func<T, TResult> f10,
+            T t11, Func<T, TResult> f11,
+            T t12, Func<T, TResult> f12,
+            T t13, Func<T, TResult> f13,
+            T t14, Func<T, TResult> f14,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -2303,23 +2303,23 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            T6 t6, Action<T6> f6,
-            T7 t7, Action<T7> f7,
-            T8 t8, Action<T8> f8,
-            T9 t9, Action<T9> f9,
-            T10 t10, Action<T10> f10,
-            T11 t11, Action<T11> f11,
-            T12 t12, Action<T12> f12,
-            T13 t13, Action<T13> f13,
-            T14 t14, Action<T14> f14,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            T t6, Action<T> f6,
+            T t7, Action<T> f7,
+            T t8, Action<T> f8,
+            T t9, Action<T> f9,
+            T t10, Action<T> f10,
+            T t11, Action<T> f11,
+            T t12, Action<T> f12,
+            T t13, Action<T> f13,
+            T t14, Action<T> f14,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -2511,24 +2511,24 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            T6 t6, Func<T6, TResult> f6,
-            T7 t7, Func<T7, TResult> f7,
-            T8 t8, Func<T8, TResult> f8,
-            T9 t9, Func<T9, TResult> f9,
-            T10 t10, Func<T10, TResult> f10,
-            T11 t11, Func<T11, TResult> f11,
-            T12 t12, Func<T12, TResult> f12,
-            T13 t13, Func<T13, TResult> f13,
-            T14 t14, Func<T14, TResult> f14,
-            T15 t15, Func<T15, TResult> f15,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            T t6, Func<T, TResult> f6,
+            T t7, Func<T, TResult> f7,
+            T t8, Func<T, TResult> f8,
+            T t9, Func<T, TResult> f9,
+            T t10, Func<T, TResult> f10,
+            T t11, Func<T, TResult> f11,
+            T t12, Func<T, TResult> f12,
+            T t13, Func<T, TResult> f13,
+            T t14, Func<T, TResult> f14,
+            T t15, Func<T, TResult> f15,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -2540,24 +2540,24 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            T6 t6, Action<T6> f6,
-            T7 t7, Action<T7> f7,
-            T8 t8, Action<T8> f8,
-            T9 t9, Action<T9> f9,
-            T10 t10, Action<T10> f10,
-            T11 t11, Action<T11> f11,
-            T12 t12, Action<T12> f12,
-            T13 t13, Action<T13> f13,
-            T14 t14, Action<T14> f14,
-            T15 t15, Action<T15> f15,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            T t6, Action<T> f6,
+            T t7, Action<T> f7,
+            T t8, Action<T> f8,
+            T t9, Action<T> f9,
+            T t10, Action<T> f10,
+            T t11, Action<T> f11,
+            T t12, Action<T> f12,
+            T t13, Action<T> f13,
+            T t14, Action<T> f14,
+            T t15, Action<T> f15,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -2757,25 +2757,25 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            T6 t6, Func<T6, TResult> f6,
-            T7 t7, Func<T7, TResult> f7,
-            T8 t8, Func<T8, TResult> f8,
-            T9 t9, Func<T9, TResult> f9,
-            T10 t10, Func<T10, TResult> f10,
-            T11 t11, Func<T11, TResult> f11,
-            T12 t12, Func<T12, TResult> f12,
-            T13 t13, Func<T13, TResult> f13,
-            T14 t14, Func<T14, TResult> f14,
-            T15 t15, Func<T15, TResult> f15,
-            T16 t16, Func<T16, TResult> f16,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            T t6, Func<T, TResult> f6,
+            T t7, Func<T, TResult> f7,
+            T t8, Func<T, TResult> f8,
+            T t9, Func<T, TResult> f9,
+            T t10, Func<T, TResult> f10,
+            T t11, Func<T, TResult> f11,
+            T t12, Func<T, TResult> f12,
+            T t13, Func<T, TResult> f13,
+            T t14, Func<T, TResult> f14,
+            T t15, Func<T, TResult> f15,
+            T t16, Func<T, TResult> f16,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -2787,25 +2787,25 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            T6 t6, Action<T6> f6,
-            T7 t7, Action<T7> f7,
-            T8 t8, Action<T8> f8,
-            T9 t9, Action<T9> f9,
-            T10 t10, Action<T10> f10,
-            T11 t11, Action<T11> f11,
-            T12 t12, Action<T12> f12,
-            T13 t13, Action<T13> f13,
-            T14 t14, Action<T14> f14,
-            T15 t15, Action<T15> f15,
-            T16 t16, Action<T16> f16,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            T t6, Action<T> f6,
+            T t7, Action<T> f7,
+            T t8, Action<T> f8,
+            T t9, Action<T> f9,
+            T t10, Action<T> f10,
+            T t11, Action<T> f11,
+            T t12, Action<T> f12,
+            T t13, Action<T> f13,
+            T t14, Action<T> f14,
+            T t15, Action<T> f15,
+            T t16, Action<T> f16,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -3013,26 +3013,26 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            T6 t6, Func<T6, TResult> f6,
-            T7 t7, Func<T7, TResult> f7,
-            T8 t8, Func<T8, TResult> f8,
-            T9 t9, Func<T9, TResult> f9,
-            T10 t10, Func<T10, TResult> f10,
-            T11 t11, Func<T11, TResult> f11,
-            T12 t12, Func<T12, TResult> f12,
-            T13 t13, Func<T13, TResult> f13,
-            T14 t14, Func<T14, TResult> f14,
-            T15 t15, Func<T15, TResult> f15,
-            T16 t16, Func<T16, TResult> f16,
-            T17 t17, Func<T17, TResult> f17,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            T t6, Func<T, TResult> f6,
+            T t7, Func<T, TResult> f7,
+            T t8, Func<T, TResult> f8,
+            T t9, Func<T, TResult> f9,
+            T t10, Func<T, TResult> f10,
+            T t11, Func<T, TResult> f11,
+            T t12, Func<T, TResult> f12,
+            T t13, Func<T, TResult> f13,
+            T t14, Func<T, TResult> f14,
+            T t15, Func<T, TResult> f15,
+            T t16, Func<T, TResult> f16,
+            T t17, Func<T, TResult> f17,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -3044,26 +3044,26 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            T6 t6, Action<T6> f6,
-            T7 t7, Action<T7> f7,
-            T8 t8, Action<T8> f8,
-            T9 t9, Action<T9> f9,
-            T10 t10, Action<T10> f10,
-            T11 t11, Action<T11> f11,
-            T12 t12, Action<T12> f12,
-            T13 t13, Action<T13> f13,
-            T14 t14, Action<T14> f14,
-            T15 t15, Action<T15> f15,
-            T16 t16, Action<T16> f16,
-            T17 t17, Action<T17> f17,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            T t6, Action<T> f6,
+            T t7, Action<T> f7,
+            T t8, Action<T> f8,
+            T t9, Action<T> f9,
+            T t10, Action<T> f10,
+            T t11, Action<T> f11,
+            T t12, Action<T> f12,
+            T t13, Action<T> f13,
+            T t14, Action<T> f14,
+            T t15, Action<T> f15,
+            T t16, Action<T> f16,
+            T t17, Action<T> f17,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -3279,27 +3279,27 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult>(
-            this TValue value,
-            T1 t1, Func<T1, TResult> f1,
-            T2 t2, Func<T2, TResult> f2,
-            T3 t3, Func<T3, TResult> f3,
-            T4 t4, Func<T4, TResult> f4,
-            T5 t5, Func<T5, TResult> f5,
-            T6 t6, Func<T6, TResult> f6,
-            T7 t7, Func<T7, TResult> f7,
-            T8 t8, Func<T8, TResult> f8,
-            T9 t9, Func<T9, TResult> f9,
-            T10 t10, Func<T10, TResult> f10,
-            T11 t11, Func<T11, TResult> f11,
-            T12 t12, Func<T12, TResult> f12,
-            T13 t13, Func<T13, TResult> f13,
-            T14 t14, Func<T14, TResult> f14,
-            T15 t15, Func<T15, TResult> f15,
-            T16 t16, Func<T16, TResult> f16,
-            T17 t17, Func<T17, TResult> f17,
-            T18 t18, Func<T18, TResult> f18,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+            T t1, Func<T, TResult> f1,
+            T t2, Func<T, TResult> f2,
+            T t3, Func<T, TResult> f3,
+            T t4, Func<T, TResult> f4,
+            T t5, Func<T, TResult> f5,
+            T t6, Func<T, TResult> f6,
+            T t7, Func<T, TResult> f7,
+            T t8, Func<T, TResult> f8,
+            T t9, Func<T, TResult> f9,
+            T t10, Func<T, TResult> f10,
+            T t11, Func<T, TResult> f11,
+            T t12, Func<T, TResult> f12,
+            T t13, Func<T, TResult> f13,
+            T t14, Func<T, TResult> f14,
+            T t15, Func<T, TResult> f15,
+            T t16, Func<T, TResult> f16,
+            T t17, Func<T, TResult> f17,
+            T t18, Func<T, TResult> f18,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -3311,27 +3311,27 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
-            this TValue value,
-            T1 t1, Action<T1> f1,
-            T2 t2, Action<T2> f2,
-            T3 t3, Action<T3> f3,
-            T4 t4, Action<T4> f4,
-            T5 t5, Action<T5> f5,
-            T6 t6, Action<T6> f6,
-            T7 t7, Action<T7> f7,
-            T8 t8, Action<T8> f8,
-            T9 t9, Action<T9> f9,
-            T10 t10, Action<T10> f10,
-            T11 t11, Action<T11> f11,
-            T12 t12, Action<T12> f12,
-            T13 t13, Action<T13> f13,
-            T14 t14, Action<T14> f14,
-            T15 t15, Action<T15> f15,
-            T16 t16, Action<T16> f16,
-            T17 t17, Action<T17> f17,
-            T18 t18, Action<T18> f18,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+            T t1, Action<T> f1,
+            T t2, Action<T> f2,
+            T t3, Action<T> f3,
+            T t4, Action<T> f4,
+            T t5, Action<T> f5,
+            T t6, Action<T> f6,
+            T t7, Action<T> f7,
+            T t8, Action<T> f8,
+            T t9, Action<T> f9,
+            T t10, Action<T> f10,
+            T t11, Action<T> f11,
+            T t12, Action<T> f12,
+            T t13, Action<T> f13,
+            T t14, Action<T> f14,
+            T t15, Action<T> f15,
+            T t16, Action<T> f16,
+            T t17, Action<T> f17,
+            T t18, Action<T> f18,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {

--- a/src/FuncSharp/Extensions/ObjectExtensions.tt
+++ b/src/FuncSharp/Extensions/ObjectExtensions.tt
@@ -131,10 +131,10 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and returns result of the corresponding function.
         /// </summary>
-        public static TResult Match<TValue, <#= Types(i) #>, TResult>(
-            this TValue value,
-<#= Lines(i, j => Indent(12) + Parameter(j) + ", Func<" + Type(j) + ", TResult> f" + j, separator: ",") #>,
-            Func<TValue, TResult> otherwise = null)
+        public static TResult Match<T, TResult>(
+            this T value,
+<#= Lines(i, j => Indent(12) + "T " + Value(j) + ", Func<T, TResult> f" + j, separator: ",") #>,
+            Func<T, TResult> otherwise = null)
         {
             if (otherwise == null)
             {
@@ -146,10 +146,10 @@ namespace FuncSharp
         /// <summary>
         /// Matches the value with the specified parameters and executes the corresponding function.
         /// </summary>
-        public static void Match<TValue, <#= Types(i) #>>(
-            this TValue value,
-<#= Lines(i, j => Indent(12) + Parameter(j) + ", Action<" + Type(j) + "> f" + j, separator: ",") #>,
-            Action<TValue> otherwise = null)
+        public static void Match<T>(
+            this T value,
+<#= Lines(i, j => Indent(12) + "T " + Value(j) + ", Action<T> f" + j, separator: ",") #>,
+            Action<T> otherwise = null)
         {
             if (otherwise == null)
             {


### PR DESCRIPTION
Restricted type on value based `Match` to accept only the same type. Still can be used as the previous one with casting on `object` first, but this version prevents accidental runtime errors.