### PR TITLE
Void Match for booleans added

### DIFF
--- a/src/FuncSharp/Extensions/BooleanExtensions.cs
+++ b/src/FuncSharp/Extensions/BooleanExtensions.cs
@@ -8,5 +8,17 @@ namespace FuncSharp
         {
             return b ? ifTrue(Unit.Value) : ifFalse(Unit.Value);
         }
+
+        public static void Match(this bool b, Action<Unit> ifTrue, Action<Unit> ifFalse)
+        {
+            if (b)
+            {
+                ifTrue(Unit.Value);
+            }
+            else
+            {
+                ifFalse(Unit.Value);
+            }
+        }
     }
 }


### PR DESCRIPTION
Question. Does it have any benefit to provide Unit.Value instead of the actual boolean value?