### PR TITLE
Fix for Create that respects exception type

### DIFF
--- a/src/FuncSharp.Tests/DataTypes/Try/TryTests.cs
+++ b/src/FuncSharp.Tests/DataTypes/Try/TryTests.cs
@@ -6,8 +6,8 @@ namespace FuncSharp.Tests
 {
     public class TryTests
     {
-        private static readonly ITry<int> Success = Try.Create<int>(_ => 42);
-        private static readonly ITry<int> Exception = Try.Create<int>(_ => throw new NotImplementedException());
+        private static readonly ITry<int> Success = Try.Create<int, Exception>(_ => 42);
+        private static readonly ITry<int> Exception = Try.Create<int, Exception>(_ => throw new NotImplementedException());
 
         [Fact]
         public void Create()

--- a/src/FuncSharp.Tests/DataTypes/Try/TryTests.cs
+++ b/src/FuncSharp.Tests/DataTypes/Try/TryTests.cs
@@ -6,8 +6,8 @@ namespace FuncSharp.Tests
 {
     public class TryTests
     {
-        private static readonly ITry<int> Success = Try.Create<int, Exception>(_ => 42);
-        private static readonly ITry<int> Exception = Try.Create<int, Exception>(_ => throw new NotImplementedException());
+        private static readonly ITry<int> Success = Try.Create<int>(_ => 42);
+        private static readonly ITry<int> Exception = Try.Create<int>(_ => throw new NotImplementedException());
 
         [Fact]
         public void Create()

--- a/src/FuncSharp/DataTypes/Try/Try.cs
+++ b/src/FuncSharp/DataTypes/Try/Try.cs
@@ -27,12 +27,12 @@ namespace FuncSharp
         /// Create a new try with the result of the specified function while converting exceptions of the specified type
         /// into erroneous result.
         /// </summary>
-        public static ITry<A, E> Create<A, E>(Func<Unit, A> f)
+        public static ITry<A> Create<A, E>(Func<Unit, A> f)
             where E : Exception
         {
-            return Catch<ITry<A, E>, E>(
-                _ => Success<A, E>(f(Unit.Value)),
-                e => Error<A, E>(e)
+            return Catch<ITry<A>, E>(
+                _ => Success(f(Unit.Value)),
+                e => Error<A>(e)
             );
         }
 
@@ -41,10 +41,7 @@ namespace FuncSharp
         /// </summary>
         public static ITry<A> Create<A>(Func<Unit, A> f)
         {
-            return Catch<ITry<A>, Exception>(
-                _ => Success(f(Unit.Value)),
-                e => Error<A>(e)
-            );
+            return Create<A, Exception>(f);
         }
 
         /// <summary>

--- a/src/FuncSharp/DataTypes/Try/Try.cs
+++ b/src/FuncSharp/DataTypes/Try/Try.cs
@@ -27,12 +27,12 @@ namespace FuncSharp
         /// Create a new try with the result of the specified function while converting exceptions of the specified type
         /// into erroneous result.
         /// </summary>
-        public static ITry<A> Create<A, E>(Func<Unit, A> f)
+        public static ITry<A, E> Create<A, E>(Func<Unit, A> f)
             where E : Exception
         {
-            return Catch<ITry<A>, Exception>(
-                _ => Success(f(Unit.Value)),
-                e => Error<A>(e)
+            return Catch<ITry<A>, E>(
+                _ => Success<A, E>(f(Unit.Value)),
+                e => Error<A, E>(e)
             );
         }
 


### PR DESCRIPTION
Added Aggregates for Error types.
Create method now only handles Exception of given type when specified.