### PR TITLE
Fix index for generated factory help

### DIFF
--- a/src/FuncSharp/Coproduct/Coproduct.tt
+++ b/src/FuncSharp/Coproduct/Coproduct.tt
@@ -70,7 +70,7 @@ namespace FuncSharp
     {
 <#         for (var j = 1; j <= i; j++) { #>
         /// <summary>
-        /// Creates a new <#= i #>-dimensional coproduct with the <#= GetLowerOrdinal(i) #> value.
+        /// Creates a new <#= i #>-dimensional coproduct with the <#= GetLowerOrdinal(j) #> value.
         /// </summary>
         public static <#= CoproductType(i) #> Create<#= GetOrdinal(j) #><#= TypeBracket(i) #>(<#= Type(j) #> value)
         {


### PR DESCRIPTION
This PR fixes an index mismatch in Coproduct T4 generator.

After this fix, the generated factory methods will have the corresponding help message.

![2021-04-29 220815 Code_zft49NpeSc](https://user-images.githubusercontent.com/8374320/116612285-aadf7a00-a937-11eb-98de-2ad3db99eba9.png)
