### PR TITLE
Update ToLowerInvariant to direct GetLowerOrdinal call

### DIFF
--- a/src/FuncSharp/Coproduct/Coproduct.tt
+++ b/src/FuncSharp/Coproduct/Coproduct.tt
@@ -89,10 +89,10 @@ namespace FuncSharp
 <#    if (i > 0) { #>
 <#    for (var j = 1; j <= i; j++) { #>
         /// <summary>
-        /// Creates a new <#= i #>-dimensional coproduct with the specified value on the <#= GetOrdinal(j).ToLowerInvariant() #> position.
+        /// Creates a new <#= i #>-dimensional coproduct with the specified value on the <#= GetLowerOrdinal(j) #> position.
         /// </summary>
-        public Coproduct<#= i #>(<#= Type(j) #> <#= GetOrdinal(j).ToLowerInvariant() #>Value)
-            : this(<#= j #>, <#= GetOrdinal(j).ToLowerInvariant() #>Value)
+        public Coproduct<#= i #>(<#= Type(j) #> <#= GetLowerOrdinal(j) #>Value)
+            : this(<#= j #>, <#= GetLowerOrdinal(j) #>Value)
         {
         }
 


### PR DESCRIPTION
This PR removes `.ToLowerInvariant()` calls on return values from `GetOrdinal` with the direct `GetLowerOrdinal(...)` method calls.

This consistent with rest of the T4 template code base.