### PR TITLE
Multitarget to prehistoric net4.5

### DIFF
--- a/src/FuncSharp.Tests/FuncSharp.Tests.csproj
+++ b/src/FuncSharp.Tests/FuncSharp.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472</TargetFrameworks>
+    <TargetFramework>net472</TargetFramework>
     <RuntimeFrameworkVersion>2.0.9</RuntimeFrameworkVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591</NoWarn>

--- a/src/FuncSharp/FuncSharp.csproj
+++ b/src/FuncSharp/FuncSharp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net4.5;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591</NoWarn>
     <Version>3.0.3</Version>
@@ -155,5 +155,8 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Try.tt</DependentUpon>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" Condition="'$(TargetFramework)'=='net4.5'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This allows to reference FuncSharp from poor projects having to support WinXP with .NET Framework 4,5 without possibility of moving to some more sane .NET Framework versions.

As a followup FuncSharp can target `netstandard1.1` but it is more difficult and it is apparently not usable for some .NET Framework 4.5 projects.