### PR TITLE
Keep original fallback exception stack trace for ITry Get

### DIFF
--- a/src/FuncSharp/Try/TryExtensions.cs
+++ b/src/FuncSharp/Try/TryExtensions.cs
@@ -59,7 +59,11 @@ namespace FuncSharp
         {
             return t.Match(
                 s => s,
-                e => throw otherwise(e)
+                e =>
+                {
+                    ExceptionDispatchInfo.Capture(otherwise(e)).Throw();
+                    return default;
+                }
             );
         }
 


### PR DESCRIPTION
I would keep original exception stack trace (if it has any already) unless there is a strong reason to replace it with stack trace ending in `Get` method.

Nothing stops you from "fallbacking" a fallback:

```C#
ITry<Unit, Exception> try;
try.Get(e =>
{
    if (e is InvalidOperationException)
        return ...
    else
        return e;
});
```

In such case you loose `e` original stack trace which is unexpected and obscures the real exception root cause.

This example is not how Try is intended to be used but this is still possible and even useful in some edge cases.