### PR TITLE
Add ToGuidExact

### DIFF
--- a/src/FuncSharp.Tests/Extensions/StringExtensionsTests.cs
+++ b/src/FuncSharp.Tests/Extensions/StringExtensionsTests.cs
@@ -27,6 +27,7 @@ namespace FuncSharp.Tests
             Assert.Equal((NumberStyles)2, "AllowTrailingWhite".ToEnum<NumberStyles>().Get());
             Assert.Equal(Option.Empty<NumberStyles>(), "2".ToEnum<NumberStyles>());
             Assert.Equal(Option.Empty<NumberStyles>(), "999999999".ToEnum<NumberStyles>());
+            Assert.Equal(Option.Empty<Guid>(), "c0fb150f6bf344df984a3a0611ae5e4a".ToGuidExact());
         }
     }
 }

--- a/src/FuncSharp/Extensions/StringExtensions.cs
+++ b/src/FuncSharp/Extensions/StringExtensions.cs
@@ -79,5 +79,10 @@ namespace FuncSharp
         {
             return Tryer.Invoke<string, Guid>(Guid.TryParse, s);
         }
+
+        public static IOption<Guid> ToGuidExact(this string s, string format = "D")
+        {
+            return Tryer.Invoke<string, string, Guid>(Guid.TryParseExact, s, format);
+        }
     }
 }


### PR DESCRIPTION
since C# Guid accepts multiple formats as Guid, exposing `TryParseExact` allows to tailor parsing to specific format and allows to distinguish between strings containing ids and guid-like strings.

https://docs.microsoft.com/en-us/dotnet/api/system.guid.tostring?view=net-6.0

```
"c0fb150f6bf344df984a3a0611ae5e4a".ToGuid() => Guid
``` 

```
"c0fb150f6bf344df984a3a0611ae5e4a".ToGuidExact(format: "D") => Option.Empty<Guid>()
``` 