### PR TITLE
ToDatacube from a collection now doesn't hide duplicit keys

### DIFF
--- a/src/FuncSharp.Tests/Extensions/IEnumerableExtensionsTests.cs
+++ b/src/FuncSharp.Tests/Extensions/IEnumerableExtensionsTests.cs
@@ -30,6 +30,23 @@ namespace FuncSharp.Tests
         }
 
         [Fact]
+        public void ToDataCube()
+        {
+            var source = new List<IProduct3<string, string, string>>
+            {
+                Product3.Create("A", "B", "D"),
+                Product3.Create("A", "C", "E")
+            };
+
+            var dataCube = source.ToDataCube(s => s.ProductValue2, s => s.ProductValue3);
+            Assert.Equal(new List<string> { "B", "C" }, dataCube.Domain1);
+            Assert.Equal(new List<string> { "D", "E" }, dataCube.Values);
+
+            // A duplicit key throws exception.
+            Assert.Throws<ArgumentException>(() => source.ToDataCube(s => s.ProductValue1, s => s.ProductValue3));
+        }
+
+        [Fact]
         public void PartitionMatch()
         {
             var source = new[]

--- a/src/FuncSharp/Extensions/IEnumerableExtensions.cs
+++ b/src/FuncSharp/Extensions/IEnumerableExtensions.cs
@@ -1,4 +1,3 @@
-﻿
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/FuncSharp/Extensions/IEnumerableExtensions.cs
+++ b/src/FuncSharp/Extensions/IEnumerableExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -213,7 +214,7 @@ namespace FuncSharp
             Func<T, P1> p1,
             Func<T, TValue> value)
         {
-            return ToDataCube<T, P1, TValue, TValue>(source, p1, value, a => a, (a, b) => b);
+            return ToDataCube<T, P1, TValue, TValue>(source, p1, value, a => a, aggregation: (a, b) => throw new ArgumentException("An item with the same key has already been added."));
         }
 
         /// <summary>
@@ -225,7 +226,7 @@ namespace FuncSharp
             Func<T, P2> p2,
             Func<T, TValue> value)
         {
-            return ToDataCube<T, P1, P2, TValue, TValue>(source, p1, p2, value, a => a, (a, b) => b);
+            return ToDataCube<T, P1, P2, TValue, TValue>(source, p1, p2, value, a => a, aggregation: (a, b) => throw new ArgumentException("An item with the same key has already been added."));
         }
 
         /// <summary>
@@ -238,7 +239,7 @@ namespace FuncSharp
             Func<T, P3> p3,
             Func<T, TValue> value)
         {
-            return ToDataCube<T, P1, P2, P3, TValue, TValue>(source, p1, p2, p3, value, a => a, (a, b) => b);
+            return ToDataCube<T, P1, P2, P3, TValue, TValue>(source, p1, p2, p3, value, a => a, aggregation: (a, b) => throw new ArgumentException("An item with the same key has already been added."));
         }
 
         /// <summary>
@@ -252,7 +253,7 @@ namespace FuncSharp
             Func<T, P4> p4,
             Func<T, TValue> value)
         {
-            return ToDataCube<T, P1, P2, P3, P4, TValue, TValue>(source, p1, p2, p3, p4, value, a => a, (a, b) => b);
+            return ToDataCube<T, P1, P2, P3, P4, TValue, TValue>(source, p1, p2, p3, p4, value, a => a, aggregation: (a, b) => throw new ArgumentException("An item with the same key has already been added."));
         }
 
         /// <summary>
@@ -267,7 +268,7 @@ namespace FuncSharp
             Func<T, P5> p5,
             Func<T, TValue> value)
         {
-            return ToDataCube<T, P1, P2, P3, P4, P5, TValue, TValue>(source, p1, p2, p3, p4, p5, value, a => a, (a, b) => b);
+            return ToDataCube<T, P1, P2, P3, P4, P5, TValue, TValue>(source, p1, p2, p3, p4, p5, value, a => a, aggregation: (a, b) => throw new ArgumentException("An item with the same key has already been added."));
         }
 
         /// <summary>
@@ -283,7 +284,7 @@ namespace FuncSharp
             Func<T, P6> p6,
             Func<T, TValue> value)
         {
-            return ToDataCube<T, P1, P2, P3, P4, P5, P6, TValue, TValue>(source, p1, p2, p3, p4, p5, p6, value, a => a, (a, b) => b);
+            return ToDataCube<T, P1, P2, P3, P4, P5, P6, TValue, TValue>(source, p1, p2, p3, p4, p5, p6, value, a => a, aggregation: (a, b) => throw new ArgumentException("An item with the same key has already been added."));
         }
 
         /// <summary>

--- a/src/FuncSharp/Extensions/IEnumerableExtensions.tt
+++ b/src/FuncSharp/Extensions/IEnumerableExtensions.tt
@@ -118,7 +118,7 @@ namespace FuncSharp
 <#= Lines(i, x => Indent(12) + "Func<T, P" + x + "> p" + x, separator: ",") #>,
             Func<T, TValue> value)
         {
-            return ToDataCube<T, <#= Types(i, name: "P") #>, TValue, TValue>(source, <#= List(i, x => "p" + x) #>, value, a => a, (a, b) => b);
+            return ToDataCube<T, <#= Types(i, name: "P") #>, TValue, TValue>(source, <#= List(i, x => "p" + x) #>, value, a => a, aggregation: (a, b) => throw new ArgumentException("An item with the same key has already been added."));
         }
 <#  } #>
 <#  for (var i = 1; i <= MaxCubeArity(); i++) { #>


### PR DESCRIPTION
Made Datacube constructor from a collection behave just like a dictionary does - throw exception for duplicit keys.