### PR TITLE
Made the obsolete methods return a valid type - just in case.

### DIFF
--- a/src/FuncSharp/Collections/IEnumerableExtensions_Emptiness.cs
+++ b/src/FuncSharp/Collections/IEnumerableExtensions_Emptiness.cs
@@ -25,7 +25,7 @@ public static partial class IEnumerableExtensions
     [Obsolete("This is already a NonEmptyEnumerable.", error: true)]
     public static Option<INonEmptyEnumerable<T>> AsNonEmpty<T>(this INonEmptyEnumerable<T> source)
     {
-        throw new NotImplementedException();
+        return Option.Valued(source);
     }
 
     public static bool NonEmpty<T>(this IEnumerable<T> e)

--- a/src/FuncSharp/Collections/IEnumerableExtensions_Generic.cs
+++ b/src/FuncSharp/Collections/IEnumerableExtensions_Generic.cs
@@ -45,10 +45,20 @@ public static partial class IEnumerableExtensions
         return source;
     }
 
+    /// <summary>
+    /// Returns the list in case it is a ReadOnlyList or creates a new ReadOnlyList from it.
+    /// </summary>
+    [DebuggerStepThrough]
+    [Pure]
+    public static IReadOnlyList<T> AsReadOnlyList<T>(this INonEmptyEnumerable<T> source)
+    {
+        return source;
+    }
+
     [Obsolete("This already is of type ReadOnlyList.", error: true)]
     public static IReadOnlyList<T> AsReadOnlyList<T>(this IReadOnlyList<T> source)
     {
-        throw new NotImplementedException();
+        return source;
     }
 
     /// <summary>

--- a/src/FuncSharp/Collections/INonEmptyEnumerable.cs
+++ b/src/FuncSharp/Collections/INonEmptyEnumerable.cs
@@ -25,7 +25,4 @@ public interface INonEmptyEnumerable<out T> : IReadOnlyList<T>
 
     [Pure]
     INonEmptyEnumerable<TResult> SelectMany<TResult>(Func<T, INonEmptyEnumerable<TResult>> selector);
-
-    [Pure]
-    IReadOnlyList<T> AsReadOnly();
 }

--- a/src/FuncSharp/Collections/NonEmptyEnumerable.cs
+++ b/src/FuncSharp/Collections/NonEmptyEnumerable.cs
@@ -128,15 +128,6 @@ public class NonEmptyEnumerable<T> : IReadOnlyList<T>, INonEmptyEnumerable<T>
         return new NonEmptyEnumerable<TResult>(headResult.Head, headResult.Tail.Concat(Tail.SelectMany(selector)).ToArray());
     }
 
-    /// <summary>
-    /// Returns the NonEmptyEnumerable typed as IReadOnlyList.
-    /// </summary>
-    [Pure]
-    public IReadOnlyList<T> AsReadOnly()
-    {
-        return this;
-    }
-
     #region static Create methods
 
     public static INonEmptyEnumerable<T> Create(T head, IEnumerable<T> tail)

--- a/src/FuncSharp/FuncSharp.csproj
+++ b/src/FuncSharp/FuncSharp.csproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591</NoWarn>
-    <Version>7.0.0</Version>
-    <AssemblyVersion>7.0.0</AssemblyVersion>
-    <FileVersion>7.0.0</FileVersion>
+    <Version>7.0.1</Version>
+    <AssemblyVersion>7.0.1</AssemblyVersion>
+    <FileVersion>7.0.1</FileVersion>
     <PackageId>FuncSharp</PackageId>
     <Description>A C# library with main purpose to reduce boilerplate code and avoid bugs thanks to stronger typing. Utilizes many concepts from functional programming languages that are also applicable in C#. Originally written by Honza Široký.</Description>
     <Authors>Mews, Honza Široký</Authors>

--- a/src/FuncSharp/FuncSharp.csproj
+++ b/src/FuncSharp/FuncSharp.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/MewsSystems/FuncSharp</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>Various UX improvements to extensions of all kinds.</PackageReleaseNotes>
+    <PackageReleaseNotes>IOption interface is gone. Option is a struct, Try is a struct. Various types have been introduced such as NonEmptyString, NonEmptyEnumerable, PositiveInt etc. A lot of extensions reworked.</PackageReleaseNotes>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/MewsSystems/FuncSharp</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/FuncSharp/Strings/StringExtensions.cs
+++ b/src/FuncSharp/Strings/StringExtensions.cs
@@ -18,7 +18,7 @@ public static class StringExtensions
     [Obsolete("This is already a nonempty string", error: true)]
     public static Option<NonEmptyString> AsNonEmpty(this NonEmptyString s)
     {
-        throw new NotImplementedException();
+        return Option.Valued(s);
     }
 
     [Pure]


### PR DESCRIPTION
Also removed AsReadOnly on INonEmptyEnumerable and rather introduced a special overload of AsReadOnlyList.

I didn't bump the major version, cause I'll unlist 7.0.0 immediately.