### PR TITLE
Made the hidden methods available again.

### DIFF
--- a/src/FuncSharp.Benchmarks/Collections/IEnumerableExtensionsBenchmarks.cs
+++ b/src/FuncSharp.Benchmarks/Collections/IEnumerableExtensionsBenchmarks.cs
@@ -84,12 +84,12 @@ public class IEnumerableExtensionsBenchmarks
         var x = ArrayOfOptions.Flatten().ToArray();
     }
 
-    // //Last Result - 25.8.2023 - 35.1 ns - 128 B
-    // [Benchmark]
-    // public void FirstOption()
-    // {
-    //     var x = StringEnumerable.FirstOption();
-    // }
+    //Last Result - 25.8.2023 - 35.1 ns - 128 B
+    [Benchmark]
+    public void FirstOption()
+    {
+        var x = StringEnumerable.FirstOption();
+    }
 
     // Last Result - 25.8.2023 - 14.6 ns - 40 B
     [Benchmark]

--- a/src/FuncSharp.Tests/Collections/FirstOptionTests.cs
+++ b/src/FuncSharp.Tests/Collections/FirstOptionTests.cs
@@ -1,5 +1,4 @@
-﻿/*
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -55,4 +54,3 @@ public class FirstOptionTests
         OptionAssert.IsEmpty(array.FirstOption(t => t.Contains("ASDF")));
     }
 }
-*/

--- a/src/FuncSharp.Tests/Collections/LastOptionTests.cs
+++ b/src/FuncSharp.Tests/Collections/LastOptionTests.cs
@@ -1,5 +1,4 @@
-﻿/*
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -55,4 +54,3 @@ public class LastOptionTests
         OptionAssert.IsEmpty(array.LastOption(t => t.Contains("ASDF")));
     }
 }
-*/

--- a/src/FuncSharp.Tests/Extensions/IEnumerableExtensionsTests.cs
+++ b/src/FuncSharp.Tests/Extensions/IEnumerableExtensionsTests.cs
@@ -7,14 +7,14 @@ namespace FuncSharp.Tests;
 
 public class IEnumerableExtensionsTests
 {
-    // [Fact]
-    // public void FirstOption()
-    // {
-    //     Assert.True(new List<int>().FirstOption().IsEmpty);
-    //     Assert.True(new List<int>().LastOption().IsEmpty);
-    //     Assert.Equal(1.ToOption(), new List<int> { 1, 2, 3 }.FirstOption());
-    //     Assert.Equal(3.ToOption(), new List<int> { 1, 2, 3 }.LastOption());
-    // }
+    [Fact]
+    public void FirstOption()
+    {
+        Assert.True(new List<int>().FirstOption().IsEmpty);
+        Assert.True(new List<int>().LastOption().IsEmpty);
+        Assert.Equal(1.ToOption(), new List<int> { 1, 2, 3 }.FirstOption());
+        Assert.Equal(3.ToOption(), new List<int> { 1, 2, 3 }.LastOption());
+    }
 
     [Fact]
     public void ToCollectionDataCube()

--- a/src/FuncSharp/Collections/IEnumerableExtensions_Emptiness.cs
+++ b/src/FuncSharp/Collections/IEnumerableExtensions_Emptiness.cs
@@ -32,7 +32,6 @@ public static partial class IEnumerableExtensions
         return source.ToOption();
     }
 
-    /*
     /// <summary>
     /// Returns true if the collection contains at least one element.
     /// </summary>
@@ -72,7 +71,6 @@ public static partial class IEnumerableExtensions
         ArgumentNullException.ThrowIfNull(source, nameof(source));
         return source.Count == 0;
     }
-*/
 
     [Obsolete("This is a NonEmptyEnumerable. It's not empty.", error: true)]
     public static bool NonEmpty<T>(this INonEmptyEnumerable<T> source)

--- a/src/FuncSharp/Collections/IEnumerableExtensions_Options.cs
+++ b/src/FuncSharp/Collections/IEnumerableExtensions_Options.cs
@@ -30,7 +30,6 @@ public static partial class IEnumerableExtensions
         return source.AsNonEmpty().Map(s => s.Min(selector));
     }
 
-    /*
     /// <summary>
     /// Returns the first element satisfying the predicate or an empty option if no such element exists.
     /// </summary>
@@ -77,7 +76,6 @@ public static partial class IEnumerableExtensions
 
         return source.Reverse().FirstOption();
     }
-    */
 
     /// <summary>
     /// Returns the only value if the source contains just one value, otherwise an empty option.

--- a/src/FuncSharp/Collections/IEnumerableExtensions_ReadOnlyList.cs
+++ b/src/FuncSharp/Collections/IEnumerableExtensions_ReadOnlyList.cs
@@ -40,17 +40,17 @@ public static partial class IEnumerableExtensions
         return list.ElementAt(0);
     }
 
-    // /// <summary>
-    // /// Returns the first element inside the list or an empty option if the list is empty.
-    // /// </summary>
-    // /// <exception cref="System.ArgumentNullException">The <paramref name="list"/> parameter is null.</exception>
-    // [Pure]
-    // public static Option<T> FirstOption<T>(this IReadOnlyList<T> list)
-    // {
-    //     return list.Count == 0
-    //         ? Option.Empty<T>()
-    //         : Option.Valued(list[0]);
-    // }
+    /// <summary>
+    /// Returns the first element inside the list or an empty option if the list is empty.
+    /// </summary>
+    /// <exception cref="System.ArgumentNullException">The <paramref name="list"/> parameter is null.</exception>
+    [Pure]
+    public static Option<T> FirstOption<T>(this IReadOnlyList<T> list)
+    {
+        return list.Count == 0
+            ? Option.Empty<T>()
+            : Option.Valued(list[0]);
+    }
 
     [Pure]
     public static T Second<T>(this IReadOnlyList<T> list)
@@ -81,17 +81,17 @@ public static partial class IEnumerableExtensions
             : list[list.Count - 1];
     }
 
-    // /// <summary>
-    // /// Returns the last element inside the list or an empty option if the list is empty.
-    // /// </summary>
-    // /// <exception cref="System.ArgumentNullException">The <paramref name="list"/> parameter is null.</exception>
-    // [Pure]
-    // public static Option<T> LastOption<T>(this IReadOnlyList<T> list)
-    // {
-    //     return list.Count == 0
-    //         ? Option.Empty<T>()
-    //         : Option.Valued(list[list.Count - 1]);
-    // }
+    /// <summary>
+    /// Returns the last element inside the list or an empty option if the list is empty.
+    /// </summary>
+    /// <exception cref="System.ArgumentNullException">The <paramref name="list"/> parameter is null.</exception>
+    [Pure]
+    public static Option<T> LastOption<T>(this IReadOnlyList<T> list)
+    {
+        return list.Count == 0
+            ? Option.Empty<T>()
+            : Option.Valued(list[list.Count - 1]);
+    }
 
     [Pure]
     public static T ElementAt<T>(this IReadOnlyList<T> list, int index)

--- a/src/FuncSharp/Order/Total/TotalOrder.cs
+++ b/src/FuncSharp/Order/Total/TotalOrder.cs
@@ -340,10 +340,7 @@ public class TotalOrder<A> : PartialOrder<A>
         // Thanks to interval ordering, results of the union are formed of continuous sequences of intervals in the ordered interval collection.
         foreach (var interval in orderedIntervals)
         {
-            var lastOption = results.Count == 0
-                ? Option.Empty<Interval<A>>()
-                : Option.Valued(results[results.Count - 1]);
-            var result = lastOption.Where(r => Intersects(r, interval) || Complements(r.UpperBound, interval.LowerBound));
+            var result = results.LastOption().Where(r => Intersects(r, interval) || Complements(r.UpperBound, interval.LowerBound));
 
             // If the interval should be part of the result, replace the result with a new extended result. Otherwise, initialize a new result.
             result.Match(


### PR DESCRIPTION
The methods were hidden in https://github.com/MewsSystems/FuncSharp/pull/143 just to make sure that we don't get some exceptions by providing nulls to these methods by accident. 

Without bumping the funcsharp package. So we can keep adding more stuff that we want to release in the 8.0 version.