### PR TITLE
Removed 2 extensions that don't make sense. They're a mews method

### DIFF
--- a/src/FuncSharp/Strings/NonEmptyStringExtensions.cs
+++ b/src/FuncSharp/Strings/NonEmptyStringExtensions.cs
@@ -23,18 +23,6 @@ public static class NonEmptyStringExtensions
     }
 
     [Pure]
-    public static string SafeSubstring(this NonEmptyString s, int length)
-    {
-        return s?.Substring(length);
-    }
-
-    [Pure]
-    public static string SafeSubstring(this NonEmptyString s, int start, int length)
-    {
-        return s?.Substring(start, length);
-    }
-
-    [Pure]
     public static string GetOrElse(this Option<NonEmptyString> option, string otherwise)
     {
         if (option.NonEmpty)


### PR DESCRIPTION
These methods don't really belong to funcsharp. It's a NonEmptyString counterpart for a mews specific string extension.