### PR TITLE
Completely removed SafeEquals

### DIFF
--- a/src/FuncSharp.Tests/Collections/ExceptNullsTests.cs
+++ b/src/FuncSharp.Tests/Collections/ExceptNullsTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
-namespace FuncSharp.Tests.Collections.INonEmptyEnumerable;
+namespace FuncSharp.Tests.Collections;
 
 public class ExceptNullsTests
 {

--- a/src/FuncSharp.Tests/Collections/ExceptTests.cs
+++ b/src/FuncSharp.Tests/Collections/ExceptTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using Xunit;
 
-namespace FuncSharp.Tests.Collections.INonEmptyEnumerable;
+namespace FuncSharp.Tests.Collections;
 
 public class ExceptTests
 {

--- a/src/FuncSharp.Tests/Collections/ExceptionsAggregateTests.cs
+++ b/src/FuncSharp.Tests/Collections/ExceptionsAggregateTests.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
-namespace FuncSharp.Tests.Collections.INonEmptyEnumerable;
+namespace FuncSharp.Tests.Collections;
 
 public class CustomException : Exception
 {
     public CustomException(string message) : base(message) { }
-    public bool Equals(CustomException other) => other is not null && other.Message.SafeEquals(Message);
+    public bool Equals(CustomException other) => Message.Equals(other?.Message);
     public override bool Equals(object obj) => Equals(obj as CustomException);
     public override int GetHashCode() => Message.GetHashCode();
 }

--- a/src/FuncSharp.Tests/Collections/FirstOptionTests.cs
+++ b/src/FuncSharp.Tests/Collections/FirstOptionTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using Xunit;
 
-namespace FuncSharp.Tests.Collections.INonEmptyEnumerable;
+namespace FuncSharp.Tests.Collections;
 
 public class FirstOptionTests
 {

--- a/src/FuncSharp.Tests/Collections/FlattenTests.cs
+++ b/src/FuncSharp.Tests/Collections/FlattenTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using Xunit;
 
-namespace FuncSharp.Tests.Collections.INonEmptyEnumerable;
+namespace FuncSharp.Tests.Collections;
 
 public class FlattenTests
 {

--- a/src/FuncSharp.Tests/Collections/IsMultipleTests.cs
+++ b/src/FuncSharp.Tests/Collections/IsMultipleTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using Xunit;
 
-namespace FuncSharp.Tests.Collections.INonEmptyEnumerable;
+namespace FuncSharp.Tests.Collections;
 
 public class IsMultipleTests
 {

--- a/src/FuncSharp.Tests/Collections/IsSingleTests.cs
+++ b/src/FuncSharp.Tests/Collections/IsSingleTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using Xunit;
 
-namespace FuncSharp.Tests.Collections.INonEmptyEnumerable;
+namespace FuncSharp.Tests.Collections;
 
 public class IsSingleTests
 {

--- a/src/FuncSharp.Tests/Collections/LastOptionTests.cs
+++ b/src/FuncSharp.Tests/Collections/LastOptionTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using Xunit;
 
-namespace FuncSharp.Tests.Collections.INonEmptyEnumerable;
+namespace FuncSharp.Tests.Collections;
 
 public class LastOptionTests
 {

--- a/src/FuncSharp.Tests/Collections/SafeConcatTests.cs
+++ b/src/FuncSharp.Tests/Collections/SafeConcatTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using Xunit;
 
-namespace FuncSharp.Tests.Collections.INonEmptyEnumerable;
+namespace FuncSharp.Tests.Collections;
 
 public class SafeSafeConcatTests
 {

--- a/src/FuncSharp.Tests/Collections/SingleOptionTests.cs
+++ b/src/FuncSharp.Tests/Collections/SingleOptionTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using Xunit;
 
-namespace FuncSharp.Tests.Collections.INonEmptyEnumerable;
+namespace FuncSharp.Tests.Collections;
 
 public class SingleOptionTests
 {

--- a/src/FuncSharp.Tests/Numeric/DivideTests.cs
+++ b/src/FuncSharp.Tests/Numeric/DivideTests.cs
@@ -1,0 +1,42 @@
+﻿using Xunit;
+
+namespace FuncSharp.Tests.Numeric;
+
+public class DivideTests
+{
+    [Fact]
+    internal void SafeDivide_int()
+    {
+        Assert.Equal(0.5m, 1.SafeDivide(2));
+        Assert.Equal(1.5m, 3.SafeDivide(2));
+        Assert.Equal(14.33m, 1.SafeDivide(0, 14.33m));
+        Assert.Equal(12.12m, 3489.SafeDivide(0, 12.12m));
+    }
+
+    [Fact]
+    internal void SafeDivide_decimal()
+    {
+        Assert.Equal(0.5m, 1m.SafeDivide(2));
+        Assert.Equal(1.5m, 3m.SafeDivide(2));
+        Assert.Equal(14.33m, 1m.SafeDivide(0, 14.33m));
+        Assert.Equal(12.12m, 3489m.SafeDivide(0, 12.12m));
+    }
+
+    [Fact]
+    internal void Divide_int()
+    {
+        Assert.Equal(0.5m.ToOption(), 1.Divide(2));
+        Assert.Equal(1.5m.ToOption(), 3.Divide(2));
+        Assert.Equal(Option.Empty<decimal>(), 1.Divide(0));
+        Assert.Equal(Option.Empty<decimal>(), 3489.Divide(0));
+    }
+
+    [Fact]
+    internal void Divide_decimal()
+    {
+        Assert.Equal(0.5m.ToOption(), 1m.Divide(2));
+        Assert.Equal(1.5m.ToOption(), 3m.Divide(2));
+        Assert.Equal(Option.Empty<decimal>(), 1m.Divide(0));
+        Assert.Equal(Option.Empty<decimal>(), 3489m.Divide(0));
+    }
+}

--- a/src/FuncSharp.Tests/Strings/NonEmptyStringEqualityTests.cs
+++ b/src/FuncSharp.Tests/Strings/NonEmptyStringEqualityTests.cs
@@ -47,8 +47,6 @@ public class NonEmptyStringTests
         Assert.True(nonEmptyString == text);
         Assert.True(text.Equals(nonEmptyString));
         Assert.True(nonEmptyString.Equals(text));
-        Assert.True(text.SafeEquals(nonEmptyString));
-        Assert.True(nonEmptyString.SafeEquals(text));
         Assert.False(object.Equals(text, nonEmptyString)); // Unfortunately string doesn't override the default Equals method to compare with IEquatable<string> therefore this is false.
         Assert.True(object.Equals(nonEmptyString, text));
 
@@ -58,15 +56,11 @@ public class NonEmptyStringTests
         Assert.False(differentString.Equals(differentNonEmptyString));
         Assert.False(differentNonEmptyString == differentString);
         Assert.False(differentString == differentNonEmptyString);
-        Assert.False(differentNonEmptyString.SafeEquals(differentString));
-        Assert.False(differentString.SafeEquals(differentNonEmptyString));
         Assert.False(object.Equals(differentNonEmptyString, differentString));
         Assert.False(object.Equals(differentString, differentNonEmptyString));
 
         NonEmptyString null1 = null;
         string null2 = null;
-        Assert.True(null1.SafeEquals(null2));
-        Assert.True(null2.SafeEquals(null1));
         Assert.True(null1 == null2);
         Assert.True(null2 == null1);
         Assert.True(object.Equals(null1, null2));

--- a/src/FuncSharp/Collections/IEnumerableExtensions_ReadOnlyList.cs
+++ b/src/FuncSharp/Collections/IEnumerableExtensions_ReadOnlyList.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.Contracts;
 
 namespace FuncSharp;
@@ -112,7 +113,7 @@ public static partial class IEnumerableExtensions
     {
         for (var i = 0; i < list.Count; i++)
         {
-            if (list[i].SafeEquals(item))
+            if (Equals(list[i], item))
             {
                 return i;
             }

--- a/src/FuncSharp/Extensions/ObjectExtensions_Generic.cs
+++ b/src/FuncSharp/Extensions/ObjectExtensions_Generic.cs
@@ -13,32 +13,6 @@ namespace FuncSharp
             return NonEmptyEnumerable.Create(value);
         }
 
-        [Pure]
-        public static bool SafeEquals<T>(this T t, T other)
-        {
-            return Equals(t, other);
-        }
-
-        [Pure]
-        public static bool SafeNotEquals<T>(this T t, T other)
-        {
-            return !t.SafeEquals(other);
-        }
-
-        [Pure]
-        public static bool SafeEquals<T>(this T t, T? other)
-            where T : struct
-        {
-            return ((T?)t).SafeEquals(other);
-        }
-
-        [Pure]
-        public static bool SafeEquals<T>(this T? t, T other)
-            where T : struct
-        {
-            return t.SafeEquals((T?)other);
-        }
-
         [DebuggerStepThrough]
         [Pure]
         public static void MatchRef<A>(this A a, Action<A> action = null, Action<Unit> otherwise = null)

--- a/src/FuncSharp/FuncSharp.csproj
+++ b/src/FuncSharp/FuncSharp.csproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591</NoWarn>
-    <Version>8.0.0</Version>
-    <AssemblyVersion>8.0.0</AssemblyVersion>
-    <FileVersion>8.0.0</FileVersion>
+    <Version>9.0.0</Version>
+    <AssemblyVersion>9.0.0</AssemblyVersion>
+    <FileVersion>9.0.0</FileVersion>
     <PackageId>FuncSharp</PackageId>
     <Description>A C# library with main purpose to reduce boilerplate code and avoid bugs thanks to stronger typing. Utilizes many concepts from functional programming languages that are also applicable in C#. Originally written by Honza Široký.</Description>
     <Authors>Mews, Honza Široký</Authors>
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/MewsSystems/FuncSharp</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>Mews methods on collections now crash when the collection is null. Just like LINQ does. Added methods for better working with collections of coproducts, tries and tuples. Added a more performant Match overload for working with IEquatable.</PackageReleaseNotes>
+    <PackageReleaseNotes>Removed SafeEquals extensions because of performance issues.</PackageReleaseNotes>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/MewsSystems/FuncSharp</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/FuncSharp/Numeric/Digit.cs
+++ b/src/FuncSharp/Numeric/Digit.cs
@@ -36,7 +36,7 @@ public readonly struct Digit
             : null;
     }
 
-    public override bool Equals(object obj) => obj is Digit other && Value.SafeEquals(other.Value);
+    public override bool Equals(object obj) => obj is Digit other && Value == other.Value;
 
     public override int GetHashCode() => Value.GetHashCode();
 

--- a/src/FuncSharp/Numeric/NumberExtensions.cs
+++ b/src/FuncSharp/Numeric/NumberExtensions.cs
@@ -134,29 +134,31 @@ public static class NumberExtensions
 
     #endregion
 
-
-
-
-
-
-
     public static decimal SafeDivide(this int a, decimal b, decimal otherwise = 0)
     {
-        return Divide(a, b).GetOrElse(otherwise);
+        return b == 0
+            ? otherwise
+            : a / b;
     }
 
     public static decimal SafeDivide(this decimal a, decimal b, decimal otherwise = 0)
     {
-        return Divide(a, b).GetOrElse(otherwise);
+        return b == 0
+            ? otherwise
+            : a / b;
     }
 
     public static Option<decimal> Divide(this int a, decimal b)
     {
-        return Divide((decimal)a, b);
+        return b == 0
+            ? Option.Empty<decimal>()
+            : Option.Valued(a / b);
     }
 
     public static Option<decimal> Divide(this decimal a, decimal b)
     {
-        return b.SafeNotEquals(0).MapTrue(_ => a / b);
+        return b == 0
+            ? Option.Empty<decimal>()
+            : Option.Valued(a / b);
     }
 }

--- a/src/FuncSharp/Option/Option.cs
+++ b/src/FuncSharp/Option/Option.cs
@@ -257,7 +257,7 @@ public struct Option<A> : IOption
     {
         if (obj is Option<A> other)
         {
-            return NonEmpty == other.NonEmpty && Value.SafeEquals(other.Value);
+            return NonEmpty == other.NonEmpty && Equals(Value, other.Value);
         }
         if (typeof(A) == typeof(NonEmptyString) && obj is Option<string> otherString)
         {

--- a/src/FuncSharp/Strings/NonEmptyStringExtensions.cs
+++ b/src/FuncSharp/Strings/NonEmptyStringExtensions.cs
@@ -7,22 +7,6 @@ namespace FuncSharp;
 public static class NonEmptyStringExtensions
 {
     [Pure]
-    public static bool SafeEquals(this NonEmptyString value, string other)
-    {
-        if (value is null)
-            return other is null;
-        return value.Value.SafeEquals(other);
-    }
-
-    [Pure]
-    public static bool SafeNotEquals(this NonEmptyString value, string other)
-    {
-        if (value is null)
-            return other is not null;
-        return value.Value.SafeNotEquals(other);
-    }
-
-    [Pure]
     public static string GetOrElse(this Option<NonEmptyString> option, string otherwise)
     {
         if (option.NonEmpty)


### PR DESCRIPTION
SafeEquals method is not really a good thing for performance - all the struct types get boxed. 

For struct types, equal signs should be used. And if you really want to call equality on objects, you could use `Equals(a, b)` syntax. Plus, it would just feel inconsistent if you were comparing reference types with `SafeEquals`, but not other types like nullable structs. Therefore I'm removing the methods completely and moving them to Mews.