### PR TITLE
Making ifSecond parameter as optional on Task Option.MatchAsync

### DIFF
--- a/src/FuncSharp/Option/IOptionExtensions.cs
+++ b/src/FuncSharp/Option/IOptionExtensions.cs
@@ -369,7 +369,7 @@ public static partial class OptionExtensions
     }
 
     [Pure]
-    public static async Task MatchAsync<A>(this Option<A> option, Func<A, Task> ifFirst, Func<Unit, Task> ifSecond)
+    public static async Task MatchAsync<A>(this Option<A> option, Func<A, Task> ifFirst, Func<Unit, Task> ifSecond = null)
     {
         if (option.NonEmpty)
         {
@@ -377,7 +377,10 @@ public static partial class OptionExtensions
         }
         else
         {
-            await ifSecond(Unit.Value);
+            if (ifSecond != null)
+            {
+                await ifSecond(Unit.Value);
+            }
         }
     }
 


### PR DESCRIPTION
Let's make the second parameter optional to avoid forcing developers to specify the second function that does nothing

e.g.:
```
await myOption.MatchAsync(async r =>
    {
        await something...
        //do something else
    },
    _ => Task.CompletedTask
);
```
=>
```
await myOption.MatchAsync(async r =>
{
    await something...
    //do something else
});
```

Benchmark results:
.NET 6
![image](https://github.com/MewsSystems/FuncSharp/assets/40407201/598afb82-1f68-41ef-b5c1-e566634a65fc)
.NET 8
![image](https://github.com/MewsSystems/FuncSharp/assets/40407201/c588ac76-9395-4c10-a4d5-71d11e6c569b)
