### PR TITLE
add type of object to exception (EXP-2301)

### DIFF
--- a/src/FuncSharp.Tests/Options/GetTests.cs
+++ b/src/FuncSharp.Tests/Options/GetTests.cs
@@ -18,7 +18,8 @@ public class GetTests
     {
         Assert.Equal(42, 42.ToOption().Get());
         Assert.Equal(42, (42 as int?).ToOption().Get());
-        Assert.Throws<InvalidOperationException>(() => Option.Empty<int>().Get());
+        var exception = Assert.Throws<InvalidOperationException>(() => Option.Empty<int>().Get());
+        Assert.Contains(nameof(Int32), exception.Message);
         Assert.Throws<NullReferenceException>(() => Option.Empty<int>().Get(otherwise: _ => new NullReferenceException()));
     }
 
@@ -73,7 +74,12 @@ public class GetTests
         }
         else
         {
-            Assert.Throws<TException>(() => option.Get(otherwise));
+            var exception = Assert.Throws<TException>(() => option.Get(otherwise));
+
+            if (typeof(TException) == typeof(InvalidOperationException))
+            {
+                Assert.Contains(typeof(T).Name, exception.Message);
+            }
         }
     }
 }

--- a/src/FuncSharp/Option/Option.cs
+++ b/src/FuncSharp/Option/Option.cs
@@ -140,7 +140,7 @@ public struct Option<A> : IOption, IEquatable<Option<A>>
         {
             throw otherwise(Unit.Value);
         }
-        throw new InvalidOperationException("An empty option does not have a value.");
+        throw new InvalidOperationException($"An empty option does not have a value of type '{typeof(A).Name}'");
     }
 
     [Pure]
@@ -154,7 +154,7 @@ public struct Option<A> : IOption, IEquatable<Option<A>>
         {
             throw otherwise(Unit.Value);
         }
-        throw new InvalidOperationException("An empty option does not have a value.");
+        throw new InvalidOperationException($"An empty option does not have a value of type '{typeof(A).Name}'");
     }
 
     [Pure]


### PR DESCRIPTION
When we are getting and Empty value exception like 'An empty option does not have a value. ' and there is one or more Option<T> on the method gets complicated to understand which one is empty without a proper debugging. 
Adding the Type to the exception will add more information for investigate the problem in this cases.